### PR TITLE
modify actors_list into actor_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Now you can use sample:
 
 ```bash
 irb> m = Movie.new
-irb> m.actors_list = "Jason Statham, Joseph Gordon-Levitt, Johnny Depp, Nicolas Cage"
+irb> m.actor_list = "Jason Statham, Joseph Gordon-Levitt, Johnny Depp, Nicolas Cage"
 irb> m.actors
 ["Jason Statham", "Joseph Gordon-Levitt", "Johnny De", "Nicolas Cage"]
 irb> m.country_list = "United States| China|Mexico"


### PR DESCRIPTION
This line would raise error when assigning the values.
`irb> m.actors_list = "Jason Statham, Joseph Gordon-Levitt, Johnny Depp, Nicolas Cage"`

It should be like this,
`irb> m.actor_list = "Jason Statham, Joseph Gordon-Levitt, Johnny Depp, Nicolas Cage"`

I think give correct readme would be good for the readers. :+1: 
